### PR TITLE
Update TeacherResponse.kt

### DIFF
--- a/application-resource/src/main/kotlin/com/info/applicationresource/domain/presentation/dto/response/TeacherResponse.kt
+++ b/application-resource/src/main/kotlin/com/info/applicationresource/domain/presentation/dto/response/TeacherResponse.kt
@@ -7,8 +7,8 @@ class TeacherResponse(
     email: String,
     profileUrl: String?,
 ): UserResponse(
-    name,
     email,
+    name,
     Role.TEACHER,
     profileUrl
 ) {


### PR DESCRIPTION
UserResponse에는 email 파라미터 다음에 name 파라미터가 오는데, TeacherResponse에서는 순서가 서로 바뀌어있는 것 같습니다
혹시 의도해서 작업하신걸까요..?

https://github.com/qj0r9j0vc2/info-oauth2-server/blob/main/application-resource/src/main/kotlin/com/info/applicationresource/domain/presentation/dto/response/UserResponse.kt